### PR TITLE
change StatActivity dashboard identifier value null

### DIFF
--- a/grafana_dashboards/postgres/v8/stat-activity/dashboard.json
+++ b/grafana_dashboards/postgres/v8/stat-activity/dashboard.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1697,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [


### PR DESCRIPTION
Previous value was a numeric leading to import 
failure. This changes this value to null in order this  dashboard to be importable

/closes #741